### PR TITLE
🩹 [Patch]: Add logging for `[System.Environment]` properties

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -76,10 +76,15 @@ LogGroup 'Environment Variables' {
 
 LogGroup '[System.Environment]' {
     $props = @{}
-    [System.Environment] | Get-Member -Static -MemberType Property | Where-Object { $_.Name -notin 'StackTrace' } | ForEach-Object {
-        $props[$_.Name] = [System.Environment]::$($_.Name)
+    $propsObject = [PSCustomObject]@{}
+    [System.Environment] | Get-Member -Static -MemberType Property | Where-Object { $_.Name -notin 'StackTrace' } |
+        ForEach-Object {
+            $props[$_.Name] = [System.Environment]::$($_.Name)
+        }
+    $props.GetEnumerator() | Sort-Object Name | ForEach-Object {
+        $propsObject | Add-Member -MemberType NoteProperty -Name $_.Name -Value $_.Value
     }
-    [PSCustomObject]$props | Format-List
+    $propsObject | Format-List
 }
 
 LogGroup 'PowerShell variables' {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -74,6 +74,14 @@ LogGroup 'Environment Variables' {
     Get-ChildItem env: | Where-Object { $_.Name -notlike 'CONTEXT_*' } | Sort-Object Name | Format-Table -AutoSize -Wrap
 }
 
+LogGroup 'System.Environment' {
+    $props = @{}
+    [System.Environment] | Get-Member -Static -MemberType Property | ForEach-Object {
+        $props[$_.Name] = [System.Environment]::$($_.Name)
+    }
+    [PSCustomObject]$props | Format-List
+}
+
 LogGroup 'PowerShell variables' {
     Get-Variable | Where-Object { $_.Name -notlike 'CONTEXT_*' } | Sort-Object Name | Format-Table -AutoSize -Wrap
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -74,7 +74,7 @@ LogGroup 'Environment Variables' {
     Get-ChildItem env: | Where-Object { $_.Name -notlike 'CONTEXT_*' } | Sort-Object Name | Format-Table -AutoSize -Wrap
 }
 
-LogGroup 'System.Environment' {
+LogGroup '[System.Environment]' {
     $props = @{}
     [System.Environment] | Get-Member -Static -MemberType Property | ForEach-Object {
         $props[$_.Name] = [System.Environment]::$($_.Name)

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -76,7 +76,7 @@ LogGroup 'Environment Variables' {
 
 LogGroup '[System.Environment]' {
     $props = @{}
-    [System.Environment] | Get-Member -Static -MemberType Property | ForEach-Object {
+    [System.Environment] | Get-Member -Static -MemberType Property | Where-Object { $_.Name -notin 'StackTrace' } | ForEach-Object {
         $props[$_.Name] = [System.Environment]::$($_.Name)
     }
     [PSCustomObject]$props | Format-List


### PR DESCRIPTION
## Description

This pull request includes an enhancement to the `scripts/main.ps1` file by adding a new logging group for listing `[System.Environment]` static properties.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
