### PR TITLE
🩹 [Patch]: Add JSON logging for Host and PSStyle contexts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions # See documentation for possible values
+    directory: / # Location of package manifests
+    schedule:
+      interval: weekly

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Action-Test
         uses: ./

--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -25,8 +25,8 @@ jobs:
   Auto-Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v5
 
       - name: Auto-Release
         uses: PSModule/Auto-Release@v1

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -12,7 +12,7 @@
         If no match is found, the original value is returned unaltered.
 
         .EXAMPLE
-        Set-MaskedValue -Value 'github_pat_1234567890123456789012'
+        Set-MaskedValue -Value '<a token starting with github_pat_>'
 
         Output:
         ```powershell
@@ -22,7 +22,7 @@
         Masks a GitHub fine-grained personal access token.
 
         .EXAMPLE
-        Set-MaskedValue -Value 'ghp_abcdefghijklmnopqrstuvwxyz0123456789' #gitleaks:allow
+        Set-MaskedValue -Value '<a token starting with ghp_>'
 
         Output:
         ```powershell

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -130,6 +130,10 @@ LogGroup 'Host' {
     $Host | Select-Object * | Format-List | Out-String
 }
 
+LogGroup 'Host - Json' {
+    Write-Host "$($Host | ConvertTo-Json -Depth 10)"
+}
+
 LogGroup 'MyInvocation' {
     $MyInvocation | Select-Object * | Format-List | Out-String
 }
@@ -144,4 +148,8 @@ LogGroup 'PSSessionOption' {
 
 LogGroup 'PSStyle' {
     $PSStyle | Select-Object * | Format-List | Out-String
+}
+
+LogGroup 'PSStyle - Json' {
+    Write-Host "$($PSStyle | ConvertTo-Json -Depth 10)"
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -131,7 +131,7 @@ LogGroup 'Host' {
 }
 
 LogGroup 'Host - Json' {
-    Write-Host "$($Host | ConvertTo-Json -Depth 10)"
+    $Host | ConvertTo-Json -Depth 3
 }
 
 LogGroup 'MyInvocation' {
@@ -151,5 +151,5 @@ LogGroup 'PSStyle' {
 }
 
 LogGroup 'PSStyle - Json' {
-    Write-Host "$($PSStyle | ConvertTo-Json -Depth 10)"
+    $PSStyle | ConvertTo-Json -Depth 3
 }


### PR DESCRIPTION
## Description

This pull request introduces several updates to automation and logging in the repository, focusing on dependency management and workflow maintenance, along with improvements to script documentation and output formatting.

**Automation and Dependency Management**

* Added a new `.github/dependabot.yml` configuration to enable weekly updates for GitHub Actions dependencies using Dependabot.

**Workflow Maintenance**

* Updated all GitHub Actions workflows (`Action-Test.yml`, `Auto-Release.yml`, and `Linter.yml`) to use `actions/checkout@v5` for improved reliability and security. [[1]](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L32-R32) [[2]](diffhunk://#diff-d3f6900ee5159d4bc4ba6d893e2dd8443c2691b0490d7351cffbd7a37ed8d95aL28-R29) [[3]](diffhunk://#diff-482e65806ed9e4a7320f14964764086b91fed4a28d12e4efde1776472e147e79L22-R22)

**Script Documentation and Output Improvements**

* Revised example values in `Set-MaskedValue` documentation within `scripts/Helpers.psm1` to use generic token placeholders instead of actual token formats, enhancing security and clarity. [[1]](diffhunk://#diff-acb1351e3ba396afa6a397b0bd44b5d8ed3ffeb97a3f3ef3633e9cfd6cacf11aL15-R15) [[2]](diffhunk://#diff-acb1351e3ba396afa6a397b0bd44b5d8ed3ffeb97a3f3ef3633e9cfd6cacf11aL25-R25)
* Enhanced logging in `scripts/main.ps1` by adding new log groups that output `Host` and `PSStyle` information in JSON format for easier parsing and debugging. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R133-R136) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R152-R155)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
