### PR TITLE
🩹 [Patch]: Remove redundant GitHub event context logging from `main.ps1`

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -11,22 +11,6 @@ LogGroup 'Context: [GITHUB]' {
     $CONTEXT_GITHUB | ConvertTo-Json -Depth 100
 }
 
-LogGroup 'Context: [GITHUB_EVENT]' {
-    $CONTEXT_GITHUB.event | ConvertTo-Json -Depth 100
-}
-
-LogGroup 'Context: [GITHUB_EVENT_ENTERPRISE]' {
-    $CONTEXT_GITHUB | ConvertTo-Json -Depth 100
-}
-
-LogGroup 'Context: [GITHUB_EVENT_ORGANIZATION]' {
-    $CONTEXT_GITHUB.event.organization | ConvertTo-Json -Depth 100
-}
-
-LogGroup 'Context: [GITHUB_EVENT_REPOSITORY]' {
-    $CONTEXT_GITHUB.event.repository | ConvertTo-Json -Depth 100
-}
-
 LogGroup 'Context: [ENV]' {
     $env:CONTEXT_ENV
 }


### PR DESCRIPTION
## Description

This pull request simplifies the logging logic in the `scripts/main.ps1` script by removing several redundant log groups related to GitHub event context. Only the essential GitHub context and environment variables are now logged.

Logging simplification:

* Removed log groups for `GITHUB_EVENT`, `GITHUB_EVENT_ENTERPRISE`, `GITHUB_EVENT_ORGANIZATION`, and `GITHUB_EVENT_REPOSITORY` from the script to reduce unnecessary output and streamline context logging.