### PR TITLE
🩹 [Patch]: Update Dependabot configuration to include labels for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,8 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request makes a small configuration update to the Dependabot settings. It adds default labels to pull requests that update GitHub Actions dependencies, making it easier to identify and manage them.

- Configuration improvement:
  * [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R12): Added `dependencies` and `github-actions` labels to Dependabot PRs for GitHub Actions updates.