### PR TITLE
🩹 [Patch]: Encode all PowerShell files using UTF8 with BOM

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param()
 
 Install-PSResource -Repository PSGallery -TrustRepository -Name Net


### PR DESCRIPTION
## Description

This pull request makes a minor change to the `scripts/main.ps1` file by adding a Unicode Byte Order Mark (BOM) at the beginning of the file. This can help ensure proper encoding detection on some systems.