### PR TITLE
⚙️ [Maintenance]: Align workflows across action repositories

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,12 +28,10 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Release
-        uses: PSModule/Release-GHRepository@88c70461c8f16cc09682005bcf3b7fca4dd8dc1a # v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: PSModule/Release-GHRepository@5a5165d66f485d1aad217ef34a190178b214fdcb # v2.0.2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `PSModule/Release-GHRepository` action in the release process.

Workflow dependency update:

* Updated the `Release` job in `.github/workflows/Release.yml` to use `PSModule/Release-GHRepository` version `v2.0.2` instead of `v2.0.1`, ensuring the workflow benefits from the latest fixes and improvements.