### PR TITLE
⚙️ [Maintenance]: Bring workflows into compliance with the GitHub Actions standard

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -23,7 +23,7 @@ jobs:
   ActionTestBasic:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04, windows-2025, macos-15]
     name: Action-Test - [Basic]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   Lint:
     name: Lint code base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write # Required to create releases
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   Release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Brings this repository's inline CI workflows into line with the organization's [GitHub Actions coding standard](https://github.com/MSXOrg/docs/blob/main/src/docs/Coding-Standards/GitHub-Actions.md). Runner images are now pinned to specific versions so a runner upgrade is a deliberate, reviewable change, and release runs queue instead of aborting mid-publish.

- Fixes #29

## Changed: runner images are pinned

No workflow uses a `-latest` runner any more; every `runs-on` names a specific image.

- `Action-Test.yml` — matrix pinned to `ubuntu-24.04`, `windows-2025`, `macos-15`
- `Linter.yml` — `ubuntu-24.04`
- `Release.yml` — `ubuntu-24.04`

## Changed: release runs queue instead of cancelling

`Release.yml` now sets `cancel-in-progress: false`, so a release that is publishing queues behind an in-flight run rather than being aborted mid-write. `Action-Test.yml` and `Linter.yml` keep `cancel-in-progress: true`, since cancelling a superseded test or lint run is desirable and is not a publish action.

## Technical Details

Validated locally with `actionlint` (0 issues) on all three workflows; the linter workflow re-checks `actionlint` in CI.

These workflows are seeded from [Template-Action](https://github.com/PSModule/Template-Action); the same corrections should also land there so regenerated repositories stay compliant (tracked under [Process-PSModule#360](https://github.com/PSModule/Process-PSModule/issues/360)).

Dependabot update grouping and semver update labels are intentionally out of scope (see [MSXOrg/docs#19](https://github.com/MSXOrg/docs/issues/19) and [PSModule/Process-PSModule#359](https://github.com/PSModule/Process-PSModule/issues/359)).
